### PR TITLE
feat: Modify DTR parameters, use 3 columns to assess scaling

### DIFF
--- a/app/ml_models/controllers.py
+++ b/app/ml_models/controllers.py
@@ -83,13 +83,13 @@ def train_model():
     X,y = prepare_data(True)
     # print y.shape
     # y = y[y.columns[30:90]]
-    y = y[y.columns[30:36]]
+    y = y[y.columns[30:33]]
 
     print 'this should be y', y
     # print X[:1000]
     split = ShuffleSplit(n_splits=1, test_size=0.09, random_state=42)
     t_1 = time.clock()
-    estimator = DTR(max_features=0.99, max_depth=11, random_state=12, splitter='random', min_samples_split=.003, presort=True)
+    estimator = DTR(max_features=.999, max_depth=12, random_state=12, splitter='random', min_samples_split=.0012, presort=True)
 
     estimator3 = RFR(n_estimators=2, max_features=0.33, n_jobs=-1)
 
@@ -179,7 +179,7 @@ def train_model():
     # plot_learning_curve(estimator2, title, X[:2000], y[:2000], (0.1, 1.01), split, n_jobs=1)
     # plt.show()
 
-    title = "Learning Curves (DTR(depth 11, 0.99 features, random splits, min split .003, presort)+MOR, 12k samples, 0.09 test)"
+    title = "Learning Curves (DTR(depth 12, 0.999 features, random splits, min split .0012, presort)+MOR, 12k samples, 0.09 test, 3 columns)"
     plot_learning_curve(estimator8, title, X[:12000], y[:12000], (-0.1, 1.01), n_jobs=-1, cv=split)
     plt.show()
 


### PR DESCRIPTION
Slightly increased complexity (11->12 depth max), 0.0012 for minimum samples to produce a split, 0.999 max features used for a model, and only 3 columns of labels/distinct DTR models trained by the MOR (rather than 6 as preivously). Completed in 320s, yielding 93.5% in validation, though given training was slightly less successful at the same point, this figure is probably influenced by variance. Notice our time isn't quite half of the previous time, ~520s, meaning the time to train more (say, all 400) probably won't quite be linear, but slightly less. 

![3-12-2017 02](https://cloud.githubusercontent.com/assets/6249764/23840813/bb965f76-077e-11e7-92f5-fe3f9f79b2e2.png)
