### PR TITLE
feat: Increase depth to 18

### DIFF
--- a/app/ml_models/controllers.py
+++ b/app/ml_models/controllers.py
@@ -108,7 +108,7 @@ def train_model():
     # print X[:1000]
     split = ShuffleSplit(n_splits=1, test_size=0.09, random_state=42)
     t_1 = time.clock()
-    estimator = DTR(max_features=1.0, max_depth=13, random_state=12, splitter='random', min_samples_split=.0003, presort=False)
+    estimator = DTR(max_features=1.0, max_depth=18, random_state=12, splitter='random', min_samples_split=.0006, presort=False)
 
     estimator3 = RFR(n_estimators=2, max_features=0.33, n_jobs=-1)
 
@@ -198,7 +198,7 @@ def train_model():
     # plot_learning_curve(estimator2, title, X[:2000], y[:2000], (0.1, 1.01), split, n_jobs=1)
     # plt.show()
 
-    title = "Learning Curves (DTR(depth 13, 1.0 features, random splits, min split .0003, no presort)+MOR, 24.5k samples, 0.09 test, 3 columns)"
+    title = "Learning Curves (DTR(depth 18, 1.0 features, random splits, min split .0006, no presort)+MOR, 24.5k samples, 0.09 test, 3 columns)"
     plot_learning_curve(estimator8, title, X[:24500], y[:24500], (-0.1, 1.01), n_jobs=-1, cv=split)
     plt.show()
 


### PR DESCRIPTION
With min_samples_split still at 0.0003 (0.0006 as of this commit and currently training; this graph is for the previous incarnation with 0.0003): 

![3-17-2017 01](https://cloud.githubusercontent.com/assets/6249764/24068395/ee31579a-0b63-11e7-8eb7-d2c4cd26196c.png)

We've recaptured 95% accuracy, and this stands to improve as parameters are tuned.
PS: 95.2% to be precise, with 1494s required for training.