### PR TITLE
feat: Increase model complexity through max_depth

### DIFF
--- a/app/ml_models/controllers.py
+++ b/app/ml_models/controllers.py
@@ -108,7 +108,7 @@ def train_model():
     # print X[:1000]
     split = ShuffleSplit(n_splits=1, test_size=0.09, random_state=42)
     t_1 = time.clock()
-    estimator = DTR(max_features=1.0, max_depth=18, random_state=12, splitter='random', min_samples_split=.0006, presort=False)
+    estimator = DTR(max_features=1.0, max_depth=24, random_state=12, splitter='random', min_samples_split=.0003, presort=False)
 
     estimator3 = RFR(n_estimators=2, max_features=0.33, n_jobs=-1)
 
@@ -198,7 +198,7 @@ def train_model():
     # plot_learning_curve(estimator2, title, X[:2000], y[:2000], (0.1, 1.01), split, n_jobs=1)
     # plt.show()
 
-    title = "Learning Curves (DTR(depth 18, 1.0 features, random splits, min split .0006, no presort)+MOR, 24.5k samples, 0.09 test, 3 columns)"
+    title = "Learning Curves (DTR(depth 24, 1.0 features, random splits, min split .0003, no presort)+MOR, 24.5k samples, 0.09 test, 3 columns)"
     plot_learning_curve(estimator8, title, X[:24500], y[:24500], (-0.1, 1.01), n_jobs=-1, cv=split)
     plt.show()
 


### PR DESCRIPTION
Increasing max_depth to 24 from 21 has improved accuracy by a marginal 0.2% or so, 95.67% in the previous trial to 95.86% in the present trial. However, this has come at the expense of total time going from 1673s to 2182s, an increase of about 30%. This doesn't necessarily represent the increase in time to make a single prediction, however, since prediction pretty much only scales with max depth, whereas training time scales closer to 2^(max_depth). 

![3-19-2017 01](https://cloud.githubusercontent.com/assets/6249764/24087586/24c2db5a-0cf7-11e7-91f5-a99779a976db.png)
