### PR TITLE
refactor: Reorganize model training and validation

### DIFF
--- a/app/ml_models/controllers.py
+++ b/app/ml_models/controllers.py
@@ -36,7 +36,7 @@ enc_samples = []
 y = []
 # Read data from the csv
 # Place it into a dataframe
-def prepare_data(as_generator=False):
+def prepare_data(as_generator=False, text_encoder=False):
     filename = 'austen-sense-400-1N1S1L2U2L(2017-01-07 23:41:04.780)'
     data = pd.read_csv(os.path.dirname(__file__) + '/../../data/' + filename + '.csv')
     X = pd.DataFrame(data['sample_doc'])
@@ -87,6 +87,7 @@ def prepare_data(as_generator=False):
         sparse_matrix.append(dict(counted_sample))
 
     # X is the list of 'fit_transformed' vectors
+    # print sparse_matrix
     X = vectorizer.fit_transform(sparse_matrix)
     # for datapoint in X:
     #     print max(datapoint)
@@ -95,8 +96,76 @@ def prepare_data(as_generator=False):
     if not as_generator:
         return 'data prepared'
     else:
+        if text_encoder:
+            return X, y, vectorizer
         return X, y
 
+def plot_learning_curve(estimator, title, X, y, ylim=None, cv=None, n_jobs=1, train_sizes=np.linspace(.1, 1.0, 5)):
+    """
+    Generate a simple plot of the test and training learning curve.
+
+    Parameters
+    ----------
+    estimator : object type that implements the "fit" and "predict" methods
+        An object of that type which is cloned for each validation.
+
+    title : string
+        Title for the chart.
+
+    X : array-like, shape (n_samples, n_features)
+        Training vector, where n_samples is the number of samples and
+        n_features is the number of features.
+
+    y : array-like, shape (n_samples) or (n_samples, n_features), optional
+        Target relative to X for classification or regression;
+        None for unsupervised learning.
+
+    ylim : tuple, shape (ymin, ymax), optional
+        Defines minimum and maximum yvalues plotted.
+
+    cv : int, cross-validation generator or an iterable, optional
+        Determines the cross-validation splitting strategy.
+        Possible inputs for cv are:
+          - None, to use the default 3-fold cross-validation,
+          - integer, to specify the number of folds.
+          - An object to be used as a cross-validation generator.
+          - An iterable yielding train/test splits.
+
+        For integer/None inputs, if ``y`` is binary or multiclass,
+        :class:`StratifiedKFold` used. If the estimator is not a classifier
+        or if ``y`` is neither binary nor multiclass, :class:`KFold` is used.
+
+        Refer :ref:`User Guide <cross_validation>` for the various
+        cross-validators that can be used here.
+
+    n_jobs : integer, optional
+        Number of jobs to run in parallel (default 1).
+    """
+    plt.figure()
+    plt.title(title)
+    if ylim is not None:
+        plt.ylim(*ylim)
+    plt.xlabel("Training examples")
+    plt.ylabel("Score")
+    train_sizes, train_scores, test_scores = learning_curve(estimator, X, y, cv=cv, n_jobs=n_jobs, train_sizes=train_sizes)
+    train_scores_mean = np.mean(train_scores, axis=1)
+    train_scores_std = np.std(train_scores, axis=1)
+    test_scores_mean = np.mean(test_scores, axis=1)
+    test_scores_std = np.std(test_scores, axis=1)
+    plt.grid()
+
+    plt.fill_between(train_sizes, train_scores_mean - train_scores_std,
+                     train_scores_mean + train_scores_std, alpha=0.1,
+                     color="r")
+    plt.fill_between(train_sizes, test_scores_mean - test_scores_std,
+                     test_scores_mean + test_scores_std, alpha=0.1, color="g")
+    plt.plot(train_sizes, train_scores_mean, 'o-', color="r",
+             label="Training score")
+    plt.plot(train_sizes, test_scores_mean, 'o-', color="g",
+             label="Cross-validation score")
+    print test_scores_mean
+    plt.legend(loc="best")
+    return plt
 
 # Do a shufflesplit or other cross-validation
 # Train a classifier on the data and labels
@@ -106,7 +175,7 @@ def train_model():
     # y = y[y.columns[30:90]]
     y = y[y.columns[30:33]]
 
-    print 'this should be y', y
+    # print 'this should be y', y
     # print X[:1000]
     split = ShuffleSplit(n_splits=1, test_size=0.09, random_state=42)
     t_1 = time.clock()
@@ -120,104 +189,47 @@ def train_model():
     # MOR multioutput regression!
     estimator8 = MOR(estimator, n_jobs=-1)
 
-    # scorer = CVS(reg, X[:1000], y[:1000], cv=split, pre_dispatch=3)
-    # for score in scorer:
-        # print score
-
-
-    def plot_learning_curve(estimator, title, X, y, ylim=None, cv=None, n_jobs=1, train_sizes=np.linspace(.1, 1.0, 5)):
-        """
-        Generate a simple plot of the test and training learning curve.
-
-        Parameters
-        ----------
-        estimator : object type that implements the "fit" and "predict" methods
-            An object of that type which is cloned for each validation.
-
-        title : string
-            Title for the chart.
-
-        X : array-like, shape (n_samples, n_features)
-            Training vector, where n_samples is the number of samples and
-            n_features is the number of features.
-
-        y : array-like, shape (n_samples) or (n_samples, n_features), optional
-            Target relative to X for classification or regression;
-            None for unsupervised learning.
-
-        ylim : tuple, shape (ymin, ymax), optional
-            Defines minimum and maximum yvalues plotted.
-
-        cv : int, cross-validation generator or an iterable, optional
-            Determines the cross-validation splitting strategy.
-            Possible inputs for cv are:
-              - None, to use the default 3-fold cross-validation,
-              - integer, to specify the number of folds.
-              - An object to be used as a cross-validation generator.
-              - An iterable yielding train/test splits.
-
-            For integer/None inputs, if ``y`` is binary or multiclass,
-            :class:`StratifiedKFold` used. If the estimator is not a classifier
-            or if ``y`` is neither binary nor multiclass, :class:`KFold` is used.
-
-            Refer :ref:`User Guide <cross_validation>` for the various
-            cross-validators that can be used here.
-
-        n_jobs : integer, optional
-            Number of jobs to run in parallel (default 1).
-        """
-        plt.figure()
-        plt.title(title)
-        if ylim is not None:
-            plt.ylim(*ylim)
-        plt.xlabel("Training examples")
-        plt.ylabel("Score")
-        train_sizes, train_scores, test_scores = learning_curve(estimator, X, y, cv=cv, n_jobs=n_jobs, train_sizes=train_sizes)
-        train_scores_mean = np.mean(train_scores, axis=1)
-        train_scores_std = np.std(train_scores, axis=1)
-        test_scores_mean = np.mean(test_scores, axis=1)
-        test_scores_std = np.std(test_scores, axis=1)
-        plt.grid()
-
-        plt.fill_between(train_sizes, train_scores_mean - train_scores_std,
-                         train_scores_mean + train_scores_std, alpha=0.1,
-                         color="r")
-        plt.fill_between(train_sizes, test_scores_mean - test_scores_std,
-                         test_scores_mean + test_scores_std, alpha=0.1, color="g")
-        plt.plot(train_sizes, train_scores_mean, 'o-', color="r",
-                 label="Training score")
-        plt.plot(train_sizes, test_scores_mean, 'o-', color="g",
-                 label="Cross-validation score")
-        print test_scores_mean
-        plt.legend(loc="best")
-        return plt
-
-    # title = "Learning Curves (RFR)"
-    # plot_learning_curve(estimator2, title, X[:2000], y[:2000], (0.1, 1.01), split, n_jobs=1)
-    # plt.show()
     # Optional: Run plot_learning_curve to generate learning curves for models. Relocate this code elsewhere to improve readability.
-    title = "Learning Curves (DTR(depth 18, 1.0 features, random splits, min split .0006, presort)+MOR, 24.5k samples, 0.09 test, 3 columns)"
+    title = "Learning Curves (DTR(depth 18, 1.0 features, random splits, min split .0006, presort)+MOR, 24.5k samples, 3 columns)"
     # plot_learning_curve(estimator8, title, X[:24500], y[:24500], (-0.1, 1.01), n_jobs=-1, cv=split)
     # plt.show()
     # TODO: Rework this train_model function to focus on training and saving models
     # Fit the model to some data
-    estimator8.fit(X,y)
+    estimator8.fit(X[:24500],y[:24500])
     # Dump the model to persist it.
-    joblib.dump(estimator8, title+'.pkl')
+    joblib.dump(estimator8, title[16:]+'.pkl')
     t_2 = time.clock()
     print "Total time: ", t_2-t_1
     return 'training model'
 
 # Measure model performance with CV
 def validate_model():
+    # The vectorizer we retrieve here must be the same as that used to train the model we're validating.
+    _,_,vectorizer = prepare_data(True, True)
+
     # Retrieve a model from a .pkl file with joblib.load()
-    # Use an unseen dataset to score it
-    # Measuure amount of time for predictions
-    X,y = prepare_data(True)
-    title = 'DTR(depth 18, 1.0 features, random splits, min split .0006, presort)+MOR, 24.5k samples, 0.09 test, 3 columns.pkl'
+    title = '(DTR(depth 18, 1.0 features, random splits, min split .0006, presort)+MOR, 10k samples, 3 columns).pkl'
     estimator = joblib.load(title)
-    estimator.fit(X,y)
-    joblib.dump(estimator, title)
-    print 'prediction', estimator.predict(X[1])
-    print 'actual', y[1]
+
+    # Use an unseen dataset to score it
+    filename = 'science_fiction-brown-400-1N1S1L2U2L(2017-01-17 17:30:39.071)'
+    data = pd.read_csv(os.path.dirname(__file__) + '/../../data/' + filename + '.csv')
+    X = pd.DataFrame(data['sample_doc'])
+    y = pd.DataFrame(data[data.columns[30:33]])
+    X_array = np.ravel(X)
+    sparse_matrix = []
+
+    for sample in X_array:
+        words = sample.split(' ')
+        counted_sample = Counter()
+        counted_sample.update(words)
+        sparse_matrix.append(dict(counted_sample))
+
+    X = vectorizer.transform(sparse_matrix)
+
+    # Measure amount of time for predictions
+    t_1 = time.clock()
+    score = estimator.score(X,y)
+    t_2 = time.clock()
+    print 'model score: ', score, 'time required for',y.shape,'predictions: ',t_2-t_1
     return 'validating model'


### PR DESCRIPTION
Training will now simply train (using the fit() function) an estimator and dump it into a .pkl. This .pkl is then loaded in 'validate_model()', where it is scored on its ability to predict the correct values of outputs for previously unseen inputs from an entirely different corpus than the ones it was trained on. Incidentally, this requires use of the same vectorizer for turning words into sparse matrices as the one that was used to process the data used to train the model.