### PR TITLE
feat: Train lower complexity model with more variance tolerance

### DIFF
--- a/app/ml_models/controllers.py
+++ b/app/ml_models/controllers.py
@@ -180,7 +180,7 @@ def train_model():
     split = ShuffleSplit(n_splits=1, test_size=0.09, random_state=42)
     t_1 = time.clock()
     # Initialize model parameters
-    estimator = DTR(max_features=1.0, max_depth=18, random_state=12, splitter='random', min_samples_split=.0006, presort=True)
+    estimator = DTR(max_features=1.0, max_depth=18, random_state=12, splitter='random', min_samples_split=.009, presort=True)
 
     estimator4 = ETR(n_estimators=100, max_features=0.66, random_state=12, n_jobs=-1, bootstrap=True)
 
@@ -190,7 +190,7 @@ def train_model():
     estimator8 = MOR(estimator, n_jobs=-1)
 
     # Optional: Run plot_learning_curve to generate learning curves for models. Relocate this code elsewhere to improve readability.
-    title = "Learning Curves (DTR(depth 18, 1.0 features, random splits, min split .0006, presort)+MOR, 24.5k samples, 3 columns)"
+    title = "Learning Curves (DTR(depth 18, 1.0 features, random splits, min split .009, presort)+MOR, 24.5k samples, 3 columns)"
     # plot_learning_curve(estimator8, title, X[:24500], y[:24500], (-0.1, 1.01), n_jobs=-1, cv=split)
     # plt.show()
     # TODO: Rework this train_model function to focus on training and saving models
@@ -208,7 +208,7 @@ def validate_model():
     _,_,vectorizer = prepare_data(True, True)
 
     # Retrieve a model from a .pkl file with joblib.load()
-    title = '(DTR(depth 18, 1.0 features, random splits, min split .0006, presort)+MOR, 10k samples, 3 columns).pkl'
+    title = '(DTR(depth 18, 1.0 features, random splits, min split .006, presort)+MOR, 24.5k samples, 3 columns).pkl'
     estimator = joblib.load(title)
 
     # Use an unseen dataset to score it
@@ -232,4 +232,7 @@ def validate_model():
     score = estimator.score(X,y)
     t_2 = time.clock()
     print 'model score: ', score, 'time required for',y.shape,'predictions: ',t_2-t_1
+    predictions = estimator.predict(X)
+    for prediction in range(1,len(predictions)):
+        print 'predicted', predictions[prediction], 'actual', y.iloc[prediction]
     return 'validating model'


### PR DESCRIPTION
By increasing min_samples_split, we're increasing the number of samples required to split a node and ultimately to form leaves, thereby decreasing model complexity. The result of needing more samples to form a split means, in general, fewer splits, meaning the splits we do have should be more general and less prone to variance in the data. In the present case, we might have found analogues for variables of interest that don't generalize to other datasets, so relying on more prevalent sample differences should ultimately mean we focus on 'real' features more, and generalize better to unseen data.